### PR TITLE
fix: correct fields tab traverse

### DIFF
--- a/package/example/pubspec.lock
+++ b/package/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -40,7 +40,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -53,13 +53,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/package/example/pubspec.lock
+++ b/package/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -40,7 +40,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -53,20 +53,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/package/lib/src/core/lo_field.dart
+++ b/package/lib/src/core/lo_field.dart
@@ -51,16 +51,17 @@ class _LoFieldState<TKey, TValue> extends State<LoField<TKey, TValue>> {
   @override
   Widget build(BuildContext context) {
     final state = LoScope.of<TKey>(context);
-
-    return FocusScope(
-      child: Focus(
-        onFocusChange: (focus) => state.onFieldFocusChanged<TValue>(
-          widget.loKey,
-          focus,
-        ),
-        child: widget.builder(
-          state.fields.get<TValue>(widget.loKey),
-        ),
+    // Focus is needed to use onFocusChanged to mark fields as touched
+    return Focus(
+      skipTraversal:
+          true, // ignore this Focus becase TextField already has one of its own
+      onFocusChange: (focus) => state.onFieldFocusChanged<TValue>(
+        widget.loKey,
+        focus,
+      ),
+      debugLabel: 'LoForm:${widget.loKey.toString()}',
+      child: widget.builder(
+        state.fields.get<TValue>(widget.loKey),
       ),
     );
   }

--- a/package/lib/src/core/lo_field.dart
+++ b/package/lib/src/core/lo_field.dart
@@ -53,13 +53,12 @@ class _LoFieldState<TKey, TValue> extends State<LoField<TKey, TValue>> {
     final state = LoScope.of<TKey>(context);
     // Focus is needed to use onFocusChanged to mark fields as touched
     return Focus(
-      skipTraversal:
-          true, // ignore this Focus becase TextField already has one of its own
+      // Ignore this Focus because LoFields already have their own
+      skipTraversal: true,
       onFocusChange: (focus) => state.onFieldFocusChanged<TValue>(
         widget.loKey,
         focus,
       ),
-      debugLabel: 'LoForm:${widget.loKey.toString()}',
       child: widget.builder(
         state.fields.get<TValue>(widget.loKey),
       ),


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #5

## Testing and Review Notes

Hello, while developing multi-platform Flutter app with the awesome LoForm I have encountered a problem with UX (especially on desktop). Changing between fields with tab key did not work, because in lo_field.dart Focus was the child of FocusScope which 'traps' the tab traversal to the FocusNodes under given FocusScope. The solution was to remove FocusScope widget and add skipTraversal = true to the Focus widget (TextField already has FocusNode attached, therefore the Focus that we add does not need to be available to be focused (otherwise one tab click removes the Focus from the field and only then the next tab click moves the focus to the next FocusNode.))

To test this functionality example project can be compiled on any platform and then tab key can be used to change between fields.

All current unit tests still do pass.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit test
